### PR TITLE
fix: models missing from the model select in VS Code 1.120

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "engines": {
     "vscode": "^1.104.0"
   },
+  "enabledApiProposals": [
+    "chatProvider"
+  ],
   "categories": [
     "AI",
     "Chat"


### PR DESCRIPTION
Fix: Models missing from the model select popup menu in VS Code 1.120