### PR TITLE
feat: add Periodic Pi Sync workflow to drift-check `sync:pi` updates

### DIFF
--- a/.github/workflows/sync-cron.yml
+++ b/.github/workflows/sync-cron.yml
@@ -1,0 +1,51 @@
+# Draft: periodic model-catalog sync from Pi AI.
+# Runs the existing `sync:pi` (check) daily; if Pi data drifted from the bundled
+# catalog, applies `--write` and opens a PR for human review + publish.
+# Conservative: PR-only, no auto `vsce publish` (no VSCE_PAT in scope yet).
+name: Periodic Pi Sync
+
+on:
+  schedule:
+    - cron: '37 6 * * *'        # daily 06:37 UTC, off-peak
+  workflow_dispatch: {}        # manual trigger from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+      - run: bun install --ignore-scripts
+
+      - name: Check for catalog drift vs Pi
+        id: check
+        run: |
+          if bun run sync:pi; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply Pi updates
+        if: steps.check.outputs.drift == 'true'
+        run: bun run sync:pi:write
+
+      - name: Bump CHANGELOG + open PR
+        if: steps.check.outputs.drift == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: sync model catalog from Pi AI"
+          title: "chore: sync model catalog from Pi AI"
+          body: |
+            Automated `sync:pi:write` detected catalog drift from Pi AI and updated
+            `src/model-catalog.ts` (+ docs/models.md for nvidia). Review the diff,
+            confirm capabilities, then publish with `vsce publish`.
+          branch: auto/pi-sync
+          delete-branch: true
+          labels: automated


### PR DESCRIPTION
# PR: ci: add Periodic Pi Sync workflow (daily drift check -> PR, no auto-publish)

**Branch to open from:** `periodic-pi-sync` (currently local only; not pushed)
**Base:** `main`

## Summary
Adds a scheduled `Periodic Pi Sync` GitHub Actions workflow
(`.github/workflows/sync-cron.yml`) that keeps this provider's bundled model
catalog in sync with Pi AI.

- Runs daily at **06:37 UTC** (off-peak) and is also manually triggerable from
  the Actions tab (`workflow_dispatch`).
- On each run it runs `bun run sync:pi` to detect catalog drift vs Pi AI.
- If drift is detected, it applies the update with `bun run sync:pi:write` and
  opens an automated PR (`peter-evans/create-pull-request@v6`, branch
  `auto/pi-sync`, label `automated`) for human review.
- For this repo the catalog update also touches `docs/models.md` alongside `src/model-catalog.ts`.

## Why PR-only
Conservative by design: **no auto `vsce publish`** — there is no `VSCE_PAT`
in scope yet. A human reviews the generated diff (confirm capabilities/limits)
and publishes with `vsce publish`.

## Changed files
- `.github/workflows/sync-cron.yml` (new, +51 lines)

## Checklist before publishing
- [ ] Confirm `sync:pi` / `sync:pi:write` npm scripts exist and run on bun 1.3.8
- [ ] Confirm `peter-evans/create-pull-requests` token has `contents: write` /
      `pull-requests: write` (workflow already requests these permissions)
- [ ] Decide on a `VSCE_PAT` strategy before enabling auto-publish (out of scope here)
