### PR TITLE
feat: add Periodic Pi Sync workflow (daily drift-check -> PR)

### DIFF
--- a/.github/workflows/sync-cron.yml
+++ b/.github/workflows/sync-cron.yml
@@ -1,0 +1,51 @@
+# Draft: periodic model-catalog sync from Pi AI.
+# Runs the existing `sync:pi` (check) daily; if Pi data drifted from the bundled
+# catalog, applies `--write` and opens a PR for human review + publish.
+# Conservative: PR-only, no auto `vsce publish` (no VSCE_PAT in scope yet).
+name: Periodic Pi Sync
+
+on:
+  schedule:
+    - cron: '37 6 * * *'        # daily 06:37 UTC, off-peak
+  workflow_dispatch: {}        # manual trigger from the Actions tab
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.8
+      - run: bun install --ignore-scripts
+
+      - name: Check for catalog drift vs Pi
+        id: check
+        run: |
+          if bun run sync:pi; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply Pi updates
+        if: steps.check.outputs.drift == 'true'
+        run: bun run sync:pi:write
+
+      - name: Bump CHANGELOG + open PR
+        if: steps.check.outputs.drift == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "chore: sync model catalog from Pi AI"
+          title: "chore: sync model catalog from Pi AI"
+          body: |
+            Automated `sync:pi:write` detected catalog drift from Pi AI and updated
+            `src/model-catalog.ts` (+ docs/models.md for nvidia). Review the diff,
+            confirm capabilities, then publish with `vsce publish`.
+          branch: auto/pi-sync
+          delete-branch: true
+          labels: automated


### PR DESCRIPTION
Recreates the previously-drafted PR for adding `.github/workflows/sync-cron.yml`. A daily (06:37 UTC) GitHub Action runs `bun run sync:pi`; if Pi's AI model catalog drifted from the bundled catalog it applies `sync:pi:write` and opens an auto PR for human review + publish. Conservative: PR-only, no auto-publish (no VSCE_PAT in scope). Supersedes the closed draft PR for this branch.